### PR TITLE
Enhance generic iframe window

### DIFF
--- a/src/components/IframeWindow.vue
+++ b/src/components/IframeWindow.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { onMounted } from "vue";
+import { onMounted, ref } from "vue";
 import { useGtag } from "vue-gtag-next";
 
 const { event } = useGtag();
+const iframe = ref<HTMLIFrameElement>();
 
 const props = defineProps({
   url: {
@@ -17,6 +18,10 @@ const props = defineProps({
     type: Number,
     default: 0,
   },
+  onMount: {
+    type: Function,
+    required: false,
+  },
 });
 
 onMounted(() => {
@@ -24,11 +29,14 @@ onMounted(() => {
     url: props.url,
     title: props.title,
   });
+  if (props.onMount) {
+    props.onMount(iframe.value);
+  }
 });
 </script>
 
 <template>
-  <iframe :title="title" :frameborder="frameBorder" :src="url" />
+  <iframe ref="iframe" :title="title" :frameborder="frameBorder" :src="url" />
 </template>
 
 <style lang="css">

--- a/src/data/menuItems.ts
+++ b/src/data/menuItems.ts
@@ -6,13 +6,26 @@ import computerIcon from "../assets/computer-5.png";
 import programsIcon from "../assets/programs_icon.png";
 import taggrIcon from "../assets/taggr_icon.png";
 import dmailIcon from "../assets/dmail_icon.png";
+import { initialise } from "@open-ic/openchat-xframe";
 
 export const toolbarLeftData: ToolbarItem[] = [
   {
     name: "OpenChat",
     class: "oc",
-    url: "https://oc.app/community/ow6el-gyaaa-aaaar-av5na-cai/?ref=y3rqn-fyaaa-aaaaf-a7z6a-cai",
+    url: "",
     virtualWindow: "iframe",
+    init: (frame) => {
+      initialise(frame, {
+        targetOrigin: "https://oc.app",
+        initialPath:
+          "/community/ow6el-gyaaa-aaaar-av5na-cai/?ref=y3rqn-fyaaa-aaaaf-a7z6a-cai",
+        theme: {
+          base: "light",
+          name: "windoge98",
+          overrides: {},
+        },
+      });
+    },
   },
   {
     name: "Discord",

--- a/src/views/DesktopView.vue
+++ b/src/views/DesktopView.vue
@@ -87,6 +87,7 @@ onMounted(() => {
         x: 200,
         y: 540,
       },
+      init: item.init,
     });
 
     activateWindow(id);
@@ -116,7 +117,13 @@ function findWindow(id: number): DesktopWindow | undefined {
   return windows.find((w) => w.id === id);
 }
 
-function onResize(id: number, left: number, top: number, width: number, height: number) {
+function onResize(
+  id: number,
+  left: number,
+  top: number,
+  width: number,
+  height: number
+) {
   windows.forEach((win) => {
     if (win.id === id) {
       win.dimensions.x = left;
@@ -163,7 +170,11 @@ const getComponentForWindowType = (windowData: DesktopWindow) => {
     default:
       return {
         component: IframeWindow,
-        props: { title: windowData.title, url: windowData.url },
+        props: {
+          title: windowData.title,
+          url: windowData.url,
+          onMount: windowData.init,
+        },
       };
     // Add other cases as necessary
   }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,7 +2,6 @@
 declare module "vue-draggable-resizable-vue3";
 declare module "./hooks/icrc1-idl";
 
-
 type WindowType = "welcome" | "developers" | VirtualWindowType;
 
 type Dimensions = {
@@ -21,6 +20,7 @@ type DesktopWindow = {
   active: boolean;
   maximised: boolean;
   dimensions: Dimensions;
+  init?: (frame: HTMLIFrameElement) => void;
 };
 
 type MenuItem = {
@@ -30,6 +30,7 @@ type MenuItem = {
   icon?: string;
   iconHeight?: number;
   submenu?: StartMenuItem[];
+  init?: (frame: HTMLIFrameElement) => void;
 };
 
 type ToolbarItem = MenuItem & {


### PR DESCRIPTION
Allow an init function to optionally be called when an iframe window is mounted. This allows us to initialise the OpenChat frame correctly in order to apply the desired theme override but also to preserve the benefits of a generic iframe window component. 