### PR TITLE
fix open chat initialisation from persisted storage

### DIFF
--- a/src/stores/useWindowStore.js
+++ b/src/stores/useWindowStore.js
@@ -1,175 +1,163 @@
 // stores/windowStore.js
 import { defineStore } from "pinia";
-import { watch } from "vue";
 import WelcomeWindow from "../components/WelcomeWindow.vue";
 import DevelopersWindow from "../components/DevelopersWindow.vue";
 import IframeWindow from "../components/IframeWindow.vue";
 import defaultAppIcon from "../assets/default_app_icon.png";
 import startIcon from "../assets/start-icon.png";
+import { initialiseOpenChat } from "../utils/windowUtils";
 
 export const useWindowStore = defineStore("windowStore", {
-	setup() {
-		const store = useWindowStore();
-		watch(
-			() => store.$state,
-			(newState) => {
-				localStorage.setItem("my-window-store", JSON.stringify(newState));
-			},
-			{ deep: true }
-		);
-		watch(windows => {
-		}, { deep: true })
-
-		return store;
-	},
-	state: () => {
-		const defaultState = {
-			windows: [
-				{
-					id: 0,
-					zIndex: 100,
-					title: "About Windoge98",
-					icon: startIcon,
-					component: WelcomeWindow,
-					visible: true,
-					active: true,
-					maximised: false,
-					type: "welcome",
-					subType: "unknown",
-					dimensions: {
-						height: 570,
-						width: 600,
-						x: 100,
-						y: 5,
-					},
-				},
-				{
-					id: 1,
-					zIndex: 1,
-					title: "Developers",
-					icon: defaultAppIcon,
-					component: DevelopersWindow,
-					visible: true,
-					active: false,
-					maximised: false,
-					type: "developers",
-					subType: "unknown",
-					dimensions: {
-						height: 440,
-						width: 600,
-						x: 200,
-						y: 400,
-					},
-				},
-			],
-			highestZIndex: 100,
-			screenWidth: window.innerWidth,
-			screenHeight: window.innerHeight - 40,
-			// Add more default state properties if needed
-		};
-
-		// Load state from local storage if available
-		const savedState = localStorage.getItem("my-window-store");
-		return savedState ? JSON.parse(savedState) : defaultState;
-	},
-	actions: {
-    persistToLocalStorage() {
-      localStorage.setItem("my-window-store", JSON.stringify(this.windows));
+  state: () => {
+    const defaultState = {
+      windows: [
+        {
+          id: 0,
+          zIndex: 100,
+          title: "About Windoge98",
+          icon: startIcon,
+          component: WelcomeWindow,
+          visible: true,
+          active: true,
+          maximised: false,
+          type: "welcome",
+          subType: "unknown",
+          dimensions: {
+            height: 570,
+            width: 600,
+            x: 100,
+            y: 5,
+          },
+        },
+        {
+          id: 1,
+          zIndex: 1,
+          title: "Developers",
+          icon: defaultAppIcon,
+          component: DevelopersWindow,
+          visible: true,
+          active: false,
+          maximised: false,
+          type: "developers",
+          subType: "unknown",
+          dimensions: {
+            height: 440,
+            width: 600,
+            x: 200,
+            y: 400,
+          },
+        },
+      ],
+      highestZIndex: 100,
+      screenWidth: window.innerWidth,
+      screenHeight: window.innerHeight - 40,
+      // Add more default state properties if needed
+    };
+    return defaultState;
+  },
+  actions: {
+    activateWindow(id) {
+      this.windows.forEach((w) => {
+        w.active = w.id === id;
+        if (w.active) {
+          this.highestZIndex++;
+          w.zIndex = this.highestZIndex;
+        } else {
+          w.zIndex = 1;
+        }
+      });
+      this.getWindowById(id).visible = true;
     },
-		activateWindow(id) {
-			this.windows.forEach((w) => {
-				w.active = w.id === id;
-				if (w.active) {
-					this.highestZIndex++;
-					w.zIndex = this.highestZIndex;
-				} else {
-					w.zIndex = 1;
-				}
-			});
-			this.getWindowById(id).visible = true;
-		},
 
-		closeWindow(id) {
-			const index = this.windows.findIndex((w) => w.id == id);
-			if (index != -1) {
-				this.windows.splice(index, 1);
-			}
-			this.setActiveToLastWindow();
-		},
+    closeWindow(id) {
+      const index = this.windows.findIndex((w) => w.id == id);
+      if (index != -1) {
+        this.windows.splice(index, 1);
+      }
+      this.setActiveToLastWindow();
+    },
 
-		maximiseWindow(id) {
-			const window = this.getWindowById(id);
-			window.maximised = !window.maximised;
-		},
+    maximiseWindow(id) {
+      const window = this.getWindowById(id);
+      window.maximised = !window.maximised;
+    },
 
-		minimiseWindow(id) {
-			this.windows.forEach((w) => {
-				if (w.id == id) {
-					w.visible = false;
-				}
-			});
-			this.setActiveToLastWindow();
-		},
+    minimiseWindow(id) {
+      this.windows.forEach((w) => {
+        if (w.id == id) {
+          w.visible = false;
+        }
+      });
+      this.setActiveToLastWindow();
+    },
 
-		setActiveToLastWindow() {
-			const visibleWindows = this.windows.filter((w) => w.visible);
+    setActiveToLastWindow() {
+      const visibleWindows = this.windows.filter((w) => w.visible);
 
-			if(visibleWindows.length > 1){
-				const lastWindow = this.windows[this.windows.length - 1];
-				if (lastWindow) {
-					this.activateWindow(lastWindow.id);
-				}
-			}
-		},
+      if (visibleWindows.length > 1) {
+        const lastWindow = this.windows[this.windows.length - 1];
+        if (lastWindow) {
+          this.activateWindow(lastWindow.id);
+        }
+      }
+    },
 
-		onResize(id, left, top, width, height) {
-			const win = this.windows.find((w) => w.id === id);
-			if (win) {
-				win.dimensions.x = left;
-				win.dimensions.y = top;
-				win.dimensions.width = width;
-				win.dimensions.height = height;
-			}
-		},
+    onResize(id, left, top, width, height) {
+      const win = this.windows.find((w) => w.id === id);
+      if (win) {
+        win.dimensions.x = left;
+        win.dimensions.y = top;
+        win.dimensions.width = width;
+        win.dimensions.height = height;
+      }
+    },
     onDragEnd(id, left, top) {
       const winIndex = this.windows.findIndex((win) => win.id === id);
       if (winIndex !== -1) {
         this.windows[winIndex].dimensions.x = left;
         this.windows[winIndex].dimensions.y = top;
       }
-    },  
-	},
+    },
+  },
 
-	getters: {
-		getWindowById: (state) => (id) => {
-			return state.windows.find((w) => w.id === id);
-		},
+  getters: {
+    getWindowById: (state) => (id) => {
+      return state.windows.find((w) => w.id === id);
+    },
 
-		getComponentForWindowType: (state) => (windowData) => {
-			switch (windowData.type) {
-				case "welcome":
-					return { component: WelcomeWindow, props: {} };
-				case "developers":
-					return { component: DevelopersWindow, props: {} };
-				default:
-					return {
-						component: IframeWindow,
-						props: {
-							title: windowData.title,
-							url: windowData.url,
-							onMount: windowData?.init, // If you have specific initialization logic
-						},
-					};
-			}
-		},
-	},
-	persist: {
-		enabled: true,
-		strategies: [
-			{
-				key: "my-window-store",
-				storage: sessionStorage, // You can also use sessionStorage
-			},
-		],
-	},
+    getComponentForWindowType: (state) => (windowData) => {
+      switch (windowData.type) {
+        case "welcome":
+          return { component: WelcomeWindow, props: {} };
+        case "developers":
+          return { component: DevelopersWindow, props: {} };
+        default:
+          return {
+            component: IframeWindow,
+            props: {
+              title: windowData.title,
+              url: windowData.url,
+              onMount: windowData?.init, // If you have specific initialization logic
+            },
+          };
+      }
+    },
+  },
+  persist: {
+    enabled: true,
+    serializer: {
+      deserialize: (str) => {
+        const data = JSON.parse(str);
+        return {
+          windows: data.windows.map((w) => {
+            if ("subType" in w && w.subType === "openchat") {
+              w.init = initialiseOpenChat;
+            }
+            return w;
+          }),
+        };
+      },
+      serialize: JSON.stringify,
+    },
+  },
 });

--- a/src/views/DesktopView.vue
+++ b/src/views/DesktopView.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import { onMounted, onBeforeUpdate } from "vue";
 import Window from "../components/Window.vue";
 import Toolbar from "../components/Toolbar.vue";
 import { useWindowStore } from "../stores/useWindowStore";
-import { initialiseOpenChat } from "../utils/windowUtils";
 
 const windowStore = useWindowStore();
 const activateWindow = windowStore.activateWindow;
@@ -54,35 +52,24 @@ window.createWindow = createWindow;
 function handleActivateToolbarWindow(windowId: number) {
   activateWindow(windowId);
 }
-
-onMounted(() => {
-  windowStore.windows.forEach((window: DesktopWindow) => {
-    if (window.subType == "openchat") {
-      initialiseOpenChat;
-      window.init;
-    }
-  });
-});
-onBeforeUpdate(() => {
-  windowStore.windows.forEach((window: DesktopWindow) => {
-    if (window.subType == "openchat") {
-      initialiseOpenChat;
-      window.init;
-    }
-  });
-});
 </script>
 
 <template>
-  <div v-if="windowStore.windows" v-for="win in windowStore.windows" :key="win.id">
+  <div
+    v-if="windowStore.windows"
+    v-for="win in windowStore.windows"
+    :key="win.id"
+  >
     <vue-draggable-resizable
       class="responsive-container"
       :active="win.active"
       @activated="windowStore.activateWindow(win.id)"
-      @dragstop="(left: number, top: number) => windowStore.onDragEnd(win.id, left, top)"
+      @dragstop="
+        (left: number, top: number) => windowStore.onDragEnd(win.id, left, top)
+      "
       @resizestop="
         (left: number, top: number, width: number, height: number) =>
-        windowStore.onResize(win.id, left, top, width, height)
+          windowStore.onResize(win.id, left, top, width, height)
       "
       :style="{ zIndex: win.zIndex, display: win.visible ? 'block' : 'none' }"
       :w="win.maximised ? windowStore.screenWidth : win.dimensions.width"


### PR DESCRIPTION
I noticed that OpenChat windows were not being initialised correctly when reloaded again. This PR fixes it and removed a bunch of slightly weird code which _seems_ to be unnecessary. I'm guessing there was a point in time where we were (trying to) do the persistence manually before moving to this pinia persistence plugin? 