### PR TITLE
add desktop icons

### DIFF
--- a/src/components/Clippy.vue
+++ b/src/components/Clippy.vue
@@ -25,7 +25,7 @@ function getRandomClippyJoke() {
     style="
       position: absolute;
       bottom: 150px; /* Adjust as needed */
-      right: 20px; /* Align with Clippy */
+      right: 200px; /* Align with Clippy */
       width: 200px; /* Adjust as needed */
       padding: 10px;
       background: #fafbcf;

--- a/src/components/DesktopApp.vue
+++ b/src/components/DesktopApp.vue
@@ -1,0 +1,78 @@
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+    app: {
+        type: Object as () => { name: string; icon: string; position?: { x: number; y: number; } },
+        required: true
+    },
+    isSelected: Boolean,
+    positionStyle: Object
+});
+
+const emits = defineEmits(['select', 'dragend']);
+
+const handleSelection = (event: MouseEvent) => {
+    emits('select', { app: props.app, event });
+};
+
+const handleDragStart = (event: DragEvent) => {
+    event.dataTransfer?.setData('text/plain', JSON.stringify(props.app));
+};
+
+const handleDragEnd = (event: DragEvent) => {
+    emits('dragend', { app: props.app, event, x: event.clientX, y: event.clientY });
+};
+
+</script>
+
+<template>
+    <div class="desktop-icon" :class="{ 'icon-selected': isSelected }" :style="positionStyle" @click="handleSelection"
+        @dragstart="handleDragStart" @dragend="handleDragEnd">
+        <img :src="app.icon" :alt="app.name" />
+        <div class="desktop-icon-name">{{ app.name }}</div>
+    </div>
+</template>
+  
+<style scoped>
+.desktop-icon {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 80px;
+    height: 100px;
+    cursor: pointer;
+}
+
+.desktop-icon img {
+    width: 64px;
+    height: 64px;
+    object-fit: cover;
+    image-rendering: pixelated;
+}
+
+.desktop-icon-name {
+    font-size: 12px;
+    color: #ffffff;
+    text-align: center;
+    line-height: 1.2;
+    word-break: break-word;
+    margin-top: 6px;
+}
+
+.icon-selected {
+    background-color: #000080;
+    color: white;
+}
+
+.icon-selected img {
+    opacity: 0.5;
+}
+
+.icon-selected .desktop-icon-name {
+    color: white;
+}
+</style>
+  

--- a/src/components/DesktopApp.vue
+++ b/src/components/DesktopApp.vue
@@ -1,78 +1,94 @@
-
 <script setup lang="ts">
-import { defineProps, defineEmits } from 'vue';
+import { defineProps, defineEmits } from "vue";
 
 const props = defineProps({
-    app: {
-        type: Object as () => { name: string; icon: string; position?: { x: number; y: number; } },
-        required: true
+  app: {
+    type: Object as () => {
+      name: string;
+      icon: string;
+      position?: { x: number; y: number };
     },
-    isSelected: Boolean,
-    positionStyle: Object
+    required: true,
+  },
+  isSelected: Boolean,
+  positionStyle: Object,
 });
 
-const emits = defineEmits(['select', 'dragend']);
+const emits = defineEmits(["select", "dragend", "drop"]);
 
 const handleSelection = (event: MouseEvent) => {
-    emits('select', { app: props.app, event });
+  emits("select", { app: props.app, event });
 };
 
 const handleDragStart = (event: DragEvent) => {
-    event.dataTransfer?.setData('text/plain', JSON.stringify(props.app));
+  event.dataTransfer?.setData("text/plain", JSON.stringify(props.app));
 };
 
 const handleDragEnd = (event: DragEvent) => {
-    emits('dragend', { app: props.app, event, x: event.clientX, y: event.clientY });
+  emits("dragend", { app: props.app, event, x: event.clientX, y: event.clientY });
 };
 
+const handleDrop = (event: DragEvent) => {
+  // Prevent default behavior (Prevent from being opened as a link)
+  event.preventDefault();
+  
+  // Emit drop event with the necessary data
+  emits("drop", { app: props.app, event });
+};
 </script>
 
 <template>
-    <div class="desktop-icon" :class="{ 'icon-selected': isSelected }" :style="positionStyle" @click="handleSelection"
-        @dragstart="handleDragStart" @dragend="handleDragEnd">
-        <img :src="app.icon" :alt="app.name" />
-        <div class="desktop-icon-name">{{ app.name }}</div>
-    </div>
+  <div
+    class="desktop-icon"
+    :class="{ 'icon-selected': isSelected }"
+    :style="positionStyle"
+    @click="handleSelection"
+    @dragstart="handleDragStart"
+    @dragend="handleDragEnd"
+    @drop="handleDrop"
+  >
+    <img :src="app.icon" :alt="app.name" />
+    <div class="desktop-icon-name">{{ app.name }}</div>
+  </div>
 </template>
-  
+
 <style scoped>
 .desktop-icon {
-    position: absolute;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 80px;
-    height: 100px;
-    cursor: pointer;
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 75px;
+  padding: 4px;
+  cursor: pointer;
 }
 
 .desktop-icon img {
-    width: 64px;
-    height: 64px;
-    object-fit: cover;
-    image-rendering: pixelated;
+  width: 56px;
+  height: 100%;
+  object-fit: cover;
 }
 
 .desktop-icon-name {
-    font-size: 12px;
-    color: #ffffff;
-    text-align: center;
-    line-height: 1.2;
-    word-break: break-word;
-    margin-top: 6px;
+  font-family: "VT323" !important;
+  font-size: 14px;
+  color: #ffffff;
+  text-align: center;
+  word-break: break-word;
+  margin-top: 6px;
 }
 
 .icon-selected {
-    background-color: #000080;
-    color: white;
+  background-color: #000080;
+  z-index: 2;
+  color: white;
 }
 
 .icon-selected img {
-    opacity: 0.5;
+  opacity: 0.5;
 }
 
 .icon-selected .desktop-icon-name {
-    color: white;
+  color: white;
 }
 </style>
-  

--- a/src/components/DesktopApps.vue
+++ b/src/components/DesktopApps.vue
@@ -1,23 +1,23 @@
 // src/components/DesktopApps.vue
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
-import DesktopApp from './DesktopApp.vue';
-import { startMenuData } from '../data/menuItems';
+import { ref, computed, onMounted } from "vue";
+import DesktopApp from "./DesktopApp.vue";
+import { startMenuData } from "../data/menuItems";
 import { openNewWindow } from "../utils/windowUtils";
 
 interface MenuItem {
-    name: string;
-    icon: string;
-    url: string;
-    iconHeight?: number;
-    height?: number;
-    width?: number;
-    virtualWindow: "none" | "iframe" | "newbie_guide" | "blank" | "welcome";
-    subType: "unknown" | "openchat";
-    visible: boolean;
-    submenu?: MenuItem[];
-    position?: { x: number; y: number };
+  name: string;
+  icon: string;
+  url: string;
+  iconHeight?: number;
+  height?: number;
+  width?: number;
+  virtualWindow: "none" | "iframe" | "newbie_guide" | "blank" | "welcome";
+  subType: "unknown" | "openchat";
+  visible: boolean;
+  submenu?: MenuItem[];
+  position?: { x: number; y: number };
 }
 
 const ICON_MARGIN = 10;
@@ -25,119 +25,130 @@ const ICON_TOTAL_WIDTH = 80;
 const ICON_TOTAL_HEIGHT = 100;
 
 function arrangeIcons(apps: MenuItem[]): MenuItem[] {
-    const containerHeight = window.innerHeight;
-    const iconsPerCol = Math.floor(containerHeight / ICON_TOTAL_HEIGHT);
+  const containerHeight = window.innerHeight;
+  const iconsPerCol = Math.floor(containerHeight / ICON_TOTAL_HEIGHT);
 
-    apps.forEach((app, index) => {
-        const col = Math.floor(index / iconsPerCol); // current column based on index
-        const row = index % iconsPerCol; // current row in the current column
+  apps.forEach((app, index) => {
+    const col = Math.floor(index / iconsPerCol); // current column based on index
+    const row = index % iconsPerCol; // current row in the current column
 
-        const x = col * ICON_TOTAL_WIDTH + ICON_MARGIN;
-        const y = row * ICON_TOTAL_HEIGHT + ICON_MARGIN;
+    const x = col * ICON_TOTAL_WIDTH + ICON_MARGIN;
+    const y = row * ICON_TOTAL_HEIGHT + ICON_MARGIN;
 
-        app.position = { x, y };
-    });
+    app.position = { x, y };
+  });
 
-    return apps;
+  return apps;
 }
 
-
 let desktopApps = computed((): MenuItem[] => {
-    const apps: MenuItem[] = [];
+  const apps: MenuItem[] = [];
 
-    startMenuData.main.forEach(item => {
-        if (item.submenu) {
-            apps.push(...item.submenu);
-        }
-    });
+  startMenuData.main.forEach((item) => {
+    if (item.submenu) {
+      apps.push(...item.submenu);
+    }
+  });
 
-    startMenuData.bottom.forEach(item => {
-        if (item.submenu) {
-            apps.push(...item.submenu);
-        }
-    });
+  startMenuData.bottom.forEach((item) => {
+    if (item.submenu) {
+      apps.push(...item.submenu);
+    }
+  });
 
-    return apps;
+  return apps;
 });
 
 const selectedApps = ref<string[]>([]);
 
 function isSelected(appName: string): boolean {
-    return selectedApps.value.includes(appName);
+  return selectedApps.value.includes(appName);
 }
 
 function toggleSelection({ app, event }: { app: MenuItem; event: MouseEvent }): void {
-    const index = selectedApps.value.indexOf(app.name);
-    if (event.ctrlKey) {
-        // Ctrl+click:
-        if (index !== -1) {
-            selectedApps.value.splice(index, 1);
-        } else {
-            selectedApps.value.push(app.name);
-        }
+  const index = selectedApps.value.indexOf(app.name);
+  if (event.ctrlKey) {
+    // Ctrl+click:
+    if (index !== -1) {
+      selectedApps.value.splice(index, 1);
     } else {
-        // regular click: select only this app
-        if (index === -1) {
-            selectedApps.value = [app.name]; // Select only this app
-        } else {
-            // already selected? then its deselection time
-            if (selectedApps.value.length === 1) {
-                selectedApps.value = [];
-            } else {
-                // there are multiple selections? select only this app
-                selectedApps.value = [app.name];
-            }
-        }
+      selectedApps.value.push(app.name);
     }
-    event.preventDefault(); // Prevent text selection
+  } else {
+    // regular click: select only this app
+    if (index === -1) {
+      selectedApps.value = [app.name]; // Select only this app
+    } else {
+      // already selected? then its deselection time
+      if (selectedApps.value.length === 1) {
+        selectedApps.value = [];
+      } else {
+        // there are multiple selections? select only this app
+        selectedApps.value = [app.name];
+      }
+    }
+  }
+  event.preventDefault(); // Prevent text selection
 }
 
-
 function handleDragEnd({ app, x, y }: { app: MenuItem; x: number; y: number }) {
-    app.position = {
-        x: Math.round((x - ICON_MARGIN) / ICON_TOTAL_WIDTH) * ICON_TOTAL_WIDTH + ICON_MARGIN,
-        y: Math.round((y - ICON_MARGIN) / ICON_TOTAL_HEIGHT) * ICON_TOTAL_HEIGHT + ICON_MARGIN
-    };
+  const newX = Math.round((x - ICON_MARGIN) / ICON_TOTAL_WIDTH) * ICON_TOTAL_WIDTH + ICON_MARGIN;
+  const newY = Math.round((y - ICON_MARGIN) / ICON_TOTAL_HEIGHT) * ICON_TOTAL_HEIGHT + ICON_MARGIN;
+
+  // Find if there's an app at the new position
+  const overlappingApp = findAppByPosition(newX, newY, app.name);
+  if (overlappingApp) {
+    // Swap positions if there's an overlap
+    swapPositions(app, overlappingApp);
+  } else {
+    // If no overlap, just move the app to the new position
+    app.position = { x: newX, y: newY };
+  }
 };
 
+function findAppByPosition(x: number, y: number, excludeAppName: string): MenuItem | null {
+  return desktopApps.value.find((app) => {
+    return app.name !== excludeAppName && app.position?.x === x && app.position?.y === y;
+  }) || null;
+};
+
+function swapPositions(app1: MenuItem, app2: MenuItem) {
+  const tempPosition = app1.position;
+  app1.position = app2.position;
+  app2.position = tempPosition;
+};
 
 function handleDoubleClick(app: MenuItem) {
-    if (app.url) {
-        console.log(`Opening ${app.url}`);
-        openNewWindow(app);
-    }
-    selectedApps.value = [];
+  if (app.url) {
+    console.log(`Opening ${app.url}`);
+    openNewWindow(app);
+  }
+  selectedApps.value = [];
 }
 
 onMounted(() => {
+  arrangeIcons(desktopApps.value);
+  document.addEventListener("mousedown", (event) => {
+    if (!(event.target instanceof Element) || !event.target.closest(".desktop-icon")) {
+      selectedApps.value = [];
+    }
+  });
+  const handleResize = () => {
     arrangeIcons(desktopApps.value);
-    document.addEventListener('mousedown', (event) => {
-        if (!(event.target instanceof Element) || !event.target.closest('.desktop-icon')) {
-            selectedApps.value = [];
-        }
-    });
-    const handleResize = () => {
-        arrangeIcons(desktopApps.value);
-    };
-    window.addEventListener('resize', handleResize);
+  };
+  window.addEventListener("resize", handleResize);
 });
-
-
 </script>
 
 <template>
-    <div class="desktop-icons-container">
-        <DesktopApp v-for="app in desktopApps" :key="app.name" :app="app" :isSelected="isSelected(app.name)"
-            :positionStyle="{ left: app.position?.x + 'px', top: app.position?.y + 'px' }" @select="toggleSelection"
-            @dragend="handleDragEnd" @dblclick="() => handleDoubleClick(app)" />
-    </div>
+   <DesktopApp
+    v-for="app in desktopApps"
+    :key="app.name"
+    :app="app"
+    :isSelected="isSelected(app.name)"
+    :positionStyle="{ left: app.position?.x + 'px', top: app.position?.y + 'px' }"
+    @select="toggleSelection"
+    @dragend="handleDragEnd"
+    @dblclick="() => handleDoubleClick(app)"
+  />
 </template>
-
-<style scoped>
-.desktop-icons-container {
-    position: relative;
-    width: 100%;
-    height: 100vh;
-    overflow: hidden;
-}
-</style>

--- a/src/components/DesktopApps.vue
+++ b/src/components/DesktopApps.vue
@@ -1,0 +1,143 @@
+// src/components/DesktopApps.vue
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import DesktopApp from './DesktopApp.vue';
+import { startMenuData } from '../data/menuItems';
+import { openNewWindow } from "../utils/windowUtils";
+
+interface MenuItem {
+    name: string;
+    icon: string;
+    url: string;
+    iconHeight?: number;
+    height?: number;
+    width?: number;
+    virtualWindow: "none" | "iframe" | "newbie_guide" | "blank" | "welcome";
+    subType: "unknown" | "openchat";
+    visible: boolean;
+    submenu?: MenuItem[];
+    position?: { x: number; y: number };
+}
+
+const ICON_MARGIN = 10;
+const ICON_TOTAL_WIDTH = 80;
+const ICON_TOTAL_HEIGHT = 100;
+
+function arrangeIcons(apps: MenuItem[]): MenuItem[] {
+    const containerHeight = window.innerHeight;
+    const iconsPerCol = Math.floor(containerHeight / ICON_TOTAL_HEIGHT);
+
+    apps.forEach((app, index) => {
+        const col = Math.floor(index / iconsPerCol); // current column based on index
+        const row = index % iconsPerCol; // current row in the current column
+
+        const x = col * ICON_TOTAL_WIDTH + ICON_MARGIN;
+        const y = row * ICON_TOTAL_HEIGHT + ICON_MARGIN;
+
+        app.position = { x, y };
+    });
+
+    return apps;
+}
+
+
+let desktopApps = computed((): MenuItem[] => {
+    const apps: MenuItem[] = [];
+
+    startMenuData.main.forEach(item => {
+        if (item.submenu) {
+            apps.push(...item.submenu);
+        }
+    });
+
+    startMenuData.bottom.forEach(item => {
+        if (item.submenu) {
+            apps.push(...item.submenu);
+        }
+    });
+
+    return apps;
+});
+
+const selectedApps = ref<string[]>([]);
+
+function isSelected(appName: string): boolean {
+    return selectedApps.value.includes(appName);
+}
+
+function toggleSelection({ app, event }: { app: MenuItem; event: MouseEvent }): void {
+    const index = selectedApps.value.indexOf(app.name);
+    if (event.ctrlKey) {
+        // Ctrl+click:
+        if (index !== -1) {
+            selectedApps.value.splice(index, 1);
+        } else {
+            selectedApps.value.push(app.name);
+        }
+    } else {
+        // regular click: select only this app
+        if (index === -1) {
+            selectedApps.value = [app.name]; // Select only this app
+        } else {
+            // already selected? then its deselection time
+            if (selectedApps.value.length === 1) {
+                selectedApps.value = [];
+            } else {
+                // there are multiple selections? select only this app
+                selectedApps.value = [app.name];
+            }
+        }
+    }
+    event.preventDefault(); // Prevent text selection
+}
+
+
+function handleDragEnd({ app, x, y }: { app: MenuItem; x: number; y: number }) {
+    app.position = {
+        x: Math.round((x - ICON_MARGIN) / ICON_TOTAL_WIDTH) * ICON_TOTAL_WIDTH + ICON_MARGIN,
+        y: Math.round((y - ICON_MARGIN) / ICON_TOTAL_HEIGHT) * ICON_TOTAL_HEIGHT + ICON_MARGIN
+    };
+};
+
+
+function handleDoubleClick(app: MenuItem) {
+    if (app.url) {
+        console.log(`Opening ${app.url}`);
+        openNewWindow(app);
+    }
+    selectedApps.value = [];
+}
+
+onMounted(() => {
+    arrangeIcons(desktopApps.value);
+    document.addEventListener('mousedown', (event) => {
+        if (!(event.target instanceof Element) || !event.target.closest('.desktop-icon')) {
+            selectedApps.value = [];
+        }
+    });
+    const handleResize = () => {
+        arrangeIcons(desktopApps.value);
+    };
+    window.addEventListener('resize', handleResize);
+});
+
+
+</script>
+
+<template>
+    <div class="desktop-icons-container">
+        <DesktopApp v-for="app in desktopApps" :key="app.name" :app="app" :isSelected="isSelected(app.name)"
+            :positionStyle="{ left: app.position?.x + 'px', top: app.position?.y + 'px' }" @select="toggleSelection"
+            @dragend="handleDragEnd" @dblclick="() => handleDoubleClick(app)" />
+    </div>
+</template>
+
+<style scoped>
+.desktop-icons-container {
+    position: relative;
+    width: 100%;
+    height: 100vh;
+    overflow: hidden;
+}
+</style>

--- a/src/data/menuItems.ts
+++ b/src/data/menuItems.ts
@@ -1,3 +1,5 @@
+import { reactive } from 'vue';
+
 import icpcoinsLogo from "../assets/icpcoins_logo.png";
 import ocDogeIcon from "../assets/oc_doge_icon.png";
 import pinballIcon from "../assets/pinball-icon.png";
@@ -22,7 +24,7 @@ import walletIcon from "../assets/wallet.png"
 import coinGeckoIcon from "../assets/coingecko_logo.png"
 import cmcIcon from "../assets/cmc_logo.png"
 
-export const startMenuData: StartMenuData = {
+const startMenuDataStructure : StartMenuData = {
   main: [
     {
       name: "DApps",
@@ -247,3 +249,5 @@ export const startMenuData: StartMenuData = {
     },
   ],
 };
+export const startMenuData = reactive(startMenuDataStructure);
+

--- a/src/views/DesktopView.vue
+++ b/src/views/DesktopView.vue
@@ -4,6 +4,7 @@ import Window from "../components/Window.vue";
 import Toolbar from "../components/Toolbar.vue";
 import { useWindowStore } from "../stores/useWindowStore";
 import clippyImage from "../assets/clippy.png";
+import DesktopApps from "../components/DesktopApps.vue";
 
 const windowStore = useWindowStore();
 const activateWindow = windowStore.activateWindow;
@@ -98,6 +99,7 @@ function getRandomClippyJoke() {
       z-index: 10;
     "
   />
+  <DesktopApps />
   <Toolbar @activateToolbarWindow="handleActivateToolbarWindow" />
 </template>
 


### PR DESCRIPTION
This pull request introduces functionality for displaying and arranging desktop icons within application. The changes include logic for handling icon drag-and-drop operations, double-click actions, and automatic icon arrangement based on the window size.

Key Changes:
- Implemented a new `DesktopApp.vue` component for individual desktop icons, allowing them to be draggable and selectable.
- Added a `DesktopApps.vue` component to manage a collection of `DesktopApp` components, including their initial positioning and response to window resize events.
- Updated `menuItems.ts` to be reactive, ensuring that changes to the start menu data are reflected across the application.
- Enhanced the `DesktopView.vue` to integrate the new desktop icon components and updated the positioning of the Clippy assistant for better alignment.
- Made minor adjustments to the `Clippy.vue` for stylistic consistency and better user experience.

Please review the changes for any potential issues or improvements that can be made.
